### PR TITLE
Fix CreateLogs naming

### DIFF
--- a/log-receiver/cmd/grpc_api/main.go
+++ b/log-receiver/cmd/grpc_api/main.go
@@ -58,7 +58,7 @@ func main() {
 
 	ctx := context.Background()
 	driver.CreateTracer(ctx, clickhouse)
-	driver.СreateLogs(ctx, clickhouse)
+        driver.CreateLogs(ctx, clickhouse)
 
 	if err != nil {
 		log.Fatalf("Failed to connect to clickhouse")

--- a/log-receiver/internal/driver/clickhouse.go
+++ b/log-receiver/internal/driver/clickhouse.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
-func СreateLogs(ctx context.Context, conn driver.Conn) {
+func CreateLogs(ctx context.Context, conn driver.Conn) {
 	createTableSQL := `
 		CREATE TABLE IF NOT EXISTS logs (
 			id Int64 CODEC(ZSTD(1)),


### PR DESCRIPTION
## Summary
- normalize CreateLogs function name in clickhouse driver
- update main.go to call the corrected name

## Testing
- `go vet ./...` *(fails: missing module downloads)*
- `go build ./...` *(fails: missing module downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68489dfbe1d4832f95e9ba7b004da0f5